### PR TITLE
Updated Maven Central Repository URL for Deployments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,8 @@
 	<distributionManagement>
 		<snapshotRepository>
 			<id>ossrh</id>
-			<url>https://central.sonatype.com/content/repositories/snapshots</url>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://central.sonatype.com/service/local/staging/deploy/maven2/</url>
-		</repository>
 	</distributionManagement>
 
 	<licenses>


### PR DESCRIPTION
The wrong URL was defined, now uses the latest URL from Maven Central docs.