### PR TITLE
Fixed the Permission Issue with Forked Workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,11 +7,6 @@ on:
   push:
     branches: [ "main" ]
 
-permissions:
-  id-token: write
-  contents: write
-  pages: write
-
 jobs:
   deploy:
     uses: metricshub/workflows/.github/workflows/maven-central-deploy.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,6 @@ on:
         required: true
         default: ""
 
-permissions:
-  id-token: write
-  contents: write
-  pages: write
-
 jobs:
   release:
     uses: metricshub/workflows/.github/workflows/maven-central-release.yml@main


### PR DESCRIPTION
We used workflows from Sentry Software organization which requires to add additional permissions to repository's workflow. Now we branched to MetricsHub organization that forks workflow for reuse in all MetricsHub repositories. When workflows are in the same organization we don't have to add additional permissions.