### PR TITLE
Incompatibility between Git ≥2.51 and Maven SCM changelog (Git blocks whatchanged)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-changelog-plugin</artifactId>
-					<version>3.0.0-M1</version>
+					<version>2.3</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.apache.maven.scm</groupId>
@@ -394,7 +394,7 @@
 			<!-- changelog -->
 			<plugin>
 				<artifactId>maven-changelog-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>2.3</version>
 				<configuration>
 					<providerImplementations>
 						<git>jgit</git>

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,19 @@
 					<version>0.7.0</version>
 				</plugin>
 
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-changelog-plugin</artifactId>
+					<version>3.0.0-M1</version>
+					<dependencies>
+						<dependency>
+							<groupId>org.apache.maven.scm</groupId>
+							<artifactId>maven-scm-provider-jgit</artifactId>
+							<version>2.1.0</version>
+							</dependency>
+					</dependencies>
+				</plugin>
+
 			</plugins>
 		</pluginManagement>
 
@@ -381,7 +394,12 @@
 			<!-- changelog -->
 			<plugin>
 				<artifactId>maven-changelog-plugin</artifactId>
-				<version>2.3</version>
+				<version>3.0.0-M1</version>
+				<configuration>
+					<providerImplementations>
+						<git>jgit</git>
+					</providerImplementations>
+				</configuration>
 			</plugin>
 
 


### PR DESCRIPTION
* Updated pom.xml

#### Tested: 
<img width="1056" height="747" alt="Capture d'écran 2025-08-22 115943" src="https://github.com/user-attachments/assets/4dcd3d35-8a8e-4f3c-8db2-df844eb1c90f" />

