### PR TITLE
Incompatibility between Git ≥2.51 and Maven SCM changelog (Git blocks whatchanged) 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-changelog-plugin</artifactId>
-					<version>2.3</version>
+					<version>3.0.0-M1</version>
 					<dependencies>
 						<dependency>
 							<groupId>org.apache.maven.scm</groupId>
@@ -394,7 +394,7 @@
 			<!-- changelog -->
 			<plugin>
 				<artifactId>maven-changelog-plugin</artifactId>
-				<version>2.3</version>
+				<version>3.0.0-M1</version>
 				<configuration>
 					<providerImplementations>
 						<git>jgit</git>


### PR DESCRIPTION
Update maven-changelog-plugin from 2.3 to 3.0.0-M1